### PR TITLE
Formatting of mk_template.py

### DIFF
--- a/mk_template.py
+++ b/mk_template.py
@@ -1,33 +1,37 @@
 """
     mk_template.py
 
-    Usage: 
-        > python mk_template.py <template_name>
+    Usage:
+    > python mk_template.py <template_name>
 
     Settings are edited by the user in 'tconfig_<template_name>.py'.
 
     Outputs:
-	- see CASA_scripts/mock_obs.py
+    - see CASA_scripts/mock_obs.py
 """
-import os, sys, time, importlib
-import numpy as np
-import const as const
+import os
+import sys
+from importlib import import_module
 
+# Parse the template name.
+
+template_name = sys.argv[-1]
 
 # Load template inputs
-inp = importlib.import_module('tconfig_'+sys.argv[-1])
 
+inp = import_module('tconfig_{}'.format(template_name))
 
 # Set up template storage space (if necessary)
-if inp.template_dir[-1] != '/': inp.template_dir += '/'
-if not os.path.exists(inp.template_dir):
-    os.system('mkdir '+inp.template_dir)
-    os.system('mkdir '+inp.template_dir+'sims')
-elif not os.path.exists(inp.template_dir+'sims'):
-    os.system('mkdir '+inp.template_dir+'sims')
 
+inp.template_dir += '/' if inp.template_dir[-1] != '/' else ''
+if not os.path.exists(inp.template_dir):
+    os.system('mkdir {}'.format(inp.template_dir))
+if not os.path.exists(inp.template_dir+'sims'):
+    os.system('mkdir {}sims'.format(inp.template_dir))
 
 # Generate the template
+
 os.system('rm -rf CASA_logs/mock_obs_'+sys.argv[-1]+'.log')
-os.system('casa --nologger --logfile CASA_logs/mock_obs_'+sys.argv[-1]+\
-          '.log -c CASA_scripts/mock_obs.py '+sys.argv[-1])
+os.system('casa --nologger '
+          + '--logfile CASA_logs/mock_obs_{}.log '.format(template_name)
+          + '-c CASA_scripts/mock_obs.py {}'.format(template_name))

--- a/mk_template.py
+++ b/mk_template.py
@@ -31,7 +31,7 @@ if not os.path.exists(inp.template_dir+'sims'):
 
 # Generate the template
 
-os.system('rm -rf CASA_logs/mock_obs_'+sys.argv[-1]+'.log')
-os.system('casa --nologger '
-          + '--logfile CASA_logs/mock_obs_{}.log '.format(template_name)
+os.system('rm -rf CASA_logs/mock_obs_{}.log'.format(template_name))
+os.system('casa --nologger --logfile '
+          + 'CASA_logs/mock_obs_{}.log '.format(template_name)
           + '-c CASA_scripts/mock_obs.py {}'.format(template_name))


### PR DESCRIPTION
Testing my forking and merging ability. Just formatted the `mk_template.py` file, replace any use of `sys.argv[-1]` with `template_name` so it was easier to parse the strings.